### PR TITLE
chore: Update systeminformation dependency to version ^5.25.3 and axion-release plugin to version 1.18.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.18.5'
+    id 'pl.allegro.tech.build.axion-release' version '1.18.16'
 }

--- a/package.json
+++ b/package.json
@@ -245,15 +245,15 @@
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "@vscode/vsce": "3.0.0",
+    "esbuild": "^0.23.1",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.1",
-    "esbuild": "^0.23.1",
     "prettier": "^2.3.2",
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "systeminformation": "5.23.5"
+    "systeminformation": "^5.25.3"
   },
   "bugs": {
     "url": "https://github.com/isontheline/vscode-sysmon/issues"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `axion-release` plugin version to `1.18.16`
	- Updated `systeminformation` dependency to `^5.25.3`
	- Added `esbuild` dependency at version `^0.23.1`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->